### PR TITLE
Add slide generation and display feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # pythonnotpowerpoint
+
+## Running the Application
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/brummiesteven/pythonnotpowerpoint.git
+   cd pythonnotpowerpoint
+   ```
+
+2. Create a virtual environment and activate it:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+
+3. Install the required dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Run the application:
+   ```bash
+   python app/main.py
+   ```
+
+5. Open your web browser and navigate to `http://127.0.0.1:5000` to view the slides.
+
+## Using the Slide Generation Feature
+
+1. Create your slides in the `app/templates` directory. Each slide should be an HTML file.
+
+2. Add your slides to the `slides` list in `app/main.py`.
+
+3. Start the application and navigate through the slides by clicking the "Next" button on the webpage.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,23 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+slides = [
+    'slide1.html',
+    'slide2.html',
+    'slide3.html'
+]
+
+@app.route('/')
+def index():
+    return render_template('index.html', slide=slides[0])
+
+@app.route('/slide/<int:slide_id>')
+def slide(slide_id):
+    if slide_id < len(slides):
+        return render_template(slides[slide_id])
+    else:
+        return "No more slides", 404
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', function() {
+    let currentSlide = 0;
+    const slides = [
+        'slide1.html',
+        'slide2.html',
+        'slide3.html'
+    ];
+
+    document.getElementById('next-slide').addEventListener('click', function() {
+        currentSlide++;
+        if (currentSlide < slides.length) {
+            document.querySelector('.slide').src = slides[currentSlide];
+        } else {
+            alert('No more slides');
+        }
+    });
+});

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,37 @@
+body {
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    font-family: Arial, sans-serif;
+}
+
+.slide-container {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #000;
+}
+
+.slide {
+    width: 90%;
+    height: 90%;
+    border: none;
+}
+
+button#next-slide {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    padding: 10px 20px;
+    font-size: 16px;
+    background-color: #fff;
+    border: none;
+    cursor: pointer;
+    border-radius: 5px;
+}
+
+button#next-slide:hover {
+    background-color: #ddd;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Slide Show</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+    <div class="slide-container">
+        <iframe src="{{ url_for('static', filename=slide) }}" frameborder="0" class="slide"></iframe>
+    </div>
+    <button id="next-slide">Next</button>
+    <script src="{{ url_for('static', filename='scripts.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
Add a Python web-based application to replace PowerPoint by generating and displaying slides fullscreen on a webpage.

* **README.md**
  - Add instructions on how to run the application.
  - Add instructions on how to use the slide generation feature.

* **app/main.py**
  - Import Flask and initialize the web application.
  - Define routes for generating and displaying slides.
  - Run the web application.

* **app/templates/index.html**
  - Create an HTML template for the main slide display page.
  - Include a button to navigate to the next slide.

* **app/static/styles.css**
  - Add CSS styles for the slide display page.

* **app/static/scripts.js**
  - Add JavaScript code to handle slide navigation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brummiesteven/pythonnotpowerpoint/pull/1?shareId=19b9d51f-d8df-44da-82ab-a123ee982287).